### PR TITLE
Fix AgentRegistry initialization bug

### DIFF
--- a/src/agents/registry.py
+++ b/src/agents/registry.py
@@ -1,8 +1,11 @@
 """Agent registry implementation."""
 
+import asyncio
 from pathlib import Path
-from typing import Any
 from types import TracebackType
+from typing import Any
+
+import httpx
 
 from ..config.loader import ConfigLoader
 from ..core.exceptions import ConfigurationError
@@ -20,9 +23,14 @@ class AgentRegistry(IAgentRegistry):
     ) -> None:
         self._agents: dict[str, AgentInfo] = agents or {}
         self._config_dir = config_dir
+        self._health_cache: dict[str, str] = {}
+        self._last_health_check = 0
+        self._health_cache_ttl = 60
+        self._http_client: httpx.AsyncClient | None = None
 
     async def __aenter__(self) -> "AgentRegistry":
         """Async context manager entry."""
+        await self._ensure_http_client()
         return self
 
     async def __aexit__(
@@ -32,7 +40,14 @@ class AgentRegistry(IAgentRegistry):
         exc_tb: TracebackType | None
     ) -> None:
         """Async context manager exit."""
-        pass
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def _ensure_http_client(self) -> None:
+        """Ensure the asynchronous HTTP client is initialized."""
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=10.0)
 
     async def get_agent(self, agent_id: str) -> AgentInfo | None:
         """Get agent information by ID."""
@@ -51,31 +66,6 @@ class AgentRegistry(IAgentRegistry):
         except Exception as e:
             raise ConfigurationError(f"Failed to refresh agent registry: {e}") from e
 
-    async def get_health_status(self) -> dict[str, str]:
-        """Get health status of all agents."""
-        # Health status should be checked via the message router, not directly
-        # For now, return a simple status
-        return {agent_id: "unknown" for agent_id in self._agents}
-
-    def get_all_agents(self) -> dict[str, AgentInfo]:
-        """Get all agents in the registry."""
-        return self._agents.copy()
-
-    def add_agent(self, agent_info: AgentInfo) -> None:
-        """Add an agent to the registry."""
-        self._agents[agent_info.id] = agent_info
-
-    def remove_agent(self, agent_id: str) -> None:
-        """Remove an agent from the registry."""
-        self._agents.pop(agent_id, None)
-
-    def get_agent_count(self) -> int:
-        """Get total number of agents."""
-        return len(self._agents)
-
-    def get_groups(self) -> list[str]:
-        """Get list of all groups."""
-        return list({agent.group for agent in self._agents.values()})
     async def get_health_status(self) -> dict[str, str]:
         """Get health status of all agents."""
         import time
@@ -140,7 +130,8 @@ class AgentRegistry(IAgentRegistry):
                 "description": f"Agent {agent_info.id} (card fetch failed)",
                 "url": f"http://{agent_info.fqdn}",
                 "version": "1.0.0",
-                "capabilities": agent_info.a2a_capabilities,                "error": f"Failed to fetch agent card: {str(e)}"
+                "capabilities": agent_info.a2a_capabilities,
+                "error": f"Failed to fetch agent card: {str(e)}",
             }
 
     def get_all_agents(self) -> dict[str, AgentInfo]:


### PR DESCRIPTION
## Summary
- ensure AgentRegistry initializes http client and caches
- remove duplicate method definitions
- add helper for creating the HTTP client

## Testing
- `ruff check src/agents/registry.py`
- `ruff check . | head -n 20`
- `mypy src/agents/registry.py` *(fails: missing stubs)*
- `pytest tests/test_agent_registry.py::TestAgentRegistry::test_check_agent_health_healthy -q` *(fails: coverage options)*

------
https://chatgpt.com/codex/tasks/task_e_685c00fe6cd483339a6f39975aae0cee