### PR TITLE
Update topic naming docs

### DIFF
--- a/features/manage-topics-automatically.md
+++ b/features/manage-topics-automatically.md
@@ -2,9 +2,9 @@
 
 Currently it is expected user to create topics manually.
 The topics should follow structure:
-a2a.<group>.req    - For request messages
-a2a.<group>.resp   - For response messages  
-a2a.<group>.dlq    - For dead letter messages
+a2a.<group>.requests    - For request messages
+a2a.<group>.responses   - For response messages
+a2a.<group>.deadletter  - For dead letter messages
 
 However its too complicated, the coordinator should automatically create or update these topics when it starts.
 


### PR DESCRIPTION
## Summary
- use `a2a.<group>.requests`, `a2a.<group>.responses`, and `a2a.<group>.deadletter` in topic examples

## Testing
- `ruff check` *(fails: Blank line contains whitespace, unused variables)*
- `mypy src tests` *(fails: found 276 errors)*
- `pytest` *(fails: unrecognized arguments '--cov=src --cov-report=term-missing')*

------
https://chatgpt.com/codex/tasks/task_e_685c032c60588333bb32f26c444d22cb