### PR TITLE
Fix envelope defaults and update tests

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -40,7 +40,6 @@ class AgentInfo:
             raise ValueError("Agent group cannot be empty")
 
 
-@dataclass
 class MessageEnvelope(BaseModel):
     """Envelope for messages sent via Service Bus."""
     

--- a/src/servicebus/client.py
+++ b/src/servicebus/client.py
@@ -208,7 +208,7 @@ class AzureServiceBusClient(IServiceBusClient):
         """Create Azure Service Bus message from our message."""
         # Serialize envelope and payload
         message_body = {
-            "envelope": message.envelope.__dict__,
+            "envelope": message.envelope.model_dump(),
             "payload": message.payload.decode('utf-8') if isinstance(message.payload, bytes) else message.payload
         }
 

--- a/tests/test_servicebus.py
+++ b/tests/test_servicebus.py
@@ -33,10 +33,11 @@ def servicebus_config():
 def message_envelope():
     """Message envelope fixture."""
     return MessageEnvelope(
-        to_agent="test-agent",
-        from_agent="caller-agent",
-        correlation_id="test-correlation-id",
-        group="test-group"
+        fromProxy="proxy-1",
+        toAgent="test-agent",
+        path="/test",
+        correlationId="test-correlation-id",
+        fromAgent="caller-agent",
     )
 
 
@@ -349,15 +350,14 @@ class TestMessageSubscriber:
         correlation_id = "test-correlation-123"
 
         envelope = MessageEnvelope(
-            group="blog-agents",
-            to_agent="proxy",
-            from_agent="critic",
-            proxy_id="proxy-1",
-            correlation_id=correlation_id,
-            is_stream=False,
+            fromProxy="proxy-follower",
+            toAgent="proxy",
+            toProxy="proxy-1",
+            path="/.well-known/agent.json",
+            method="GET",
+            correlationId=correlation_id,
+            fromAgent="critic",
             headers={},
-            http_path="/.well-known/agent.json",
-            http_method="GET"
         )
 
         message = ServiceBusMessage(


### PR DESCRIPTION
## Summary
- fix MessageEnvelope dataclass usage by removing dataclass decorator
- dump envelope via `model_dump` in ServiceBus client
- update tests for new MessageEnvelope fields

## Testing
- `uv run mypy src` *(fails: Statement is unreachable and unsupported assignment errors)*
- `uv run pytest tests` *(fails: SyntaxError in tests/test_topic_management_integration.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d19864ad88333a53d13ac86aba3e5